### PR TITLE
Django 5.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ By default, retries are only performed when `psycopg.errors.SerializationError` 
 
 ## Compatibility
 
-`django-pgtransaction` is compatible with Python 3.8 - 3.12, Django 3.2 - 4.2, Psycopg 2 - 3, and Postgres 12 - 16.
+`django-pgtransaction` is compatible with Python 3.8 - 3.12, Django 3.2 - 5.0, Psycopg 2 - 3, and Postgres 12 - 16.
 
 ## Documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ By default, retries are only performed when `psycopg.errors.SerializationError` 
 
 ## Compatibility
 
-`django-pgtransaction` is compatible with Python 3.8 - 3.12, Django 3.2 - 4.2, Psycopg 2 - 3, and Postgres 12 - 16.
+`django-pgtransaction` is compatible with Python 3.8 - 3.12, Django 3.2 - 5.0, Psycopg 2 - 3, and Postgres 12 - 16.
 
 ## Other Reading
 

--- a/footing.yaml
+++ b/footing.yaml
@@ -1,7 +1,7 @@
 _extensions:
 - jinja2_time.TimeExtension
 _template: git@github.com:Opus10/public-django-app-template.git
-_version: 61fb54bab32508ca0cc5d70a9155f49d124f04c0
+_version: a2f39d5ad54f2ef63172d2b43756a85ec66eb12e
 module_name: pgtransaction
 repo_name: django-pgtransaction
 short_description: A context manager/decorator which extends Django's atomic function

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ classifiers = [
   "Framework :: Django :: 4.0",
   "Framework :: Django :: 4.1",
   "Framework :: Django :: 4.2",
+  "Framework :: Django :: 5.0",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
   "Programming Language :: Python",

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,19 @@
 [tox]
 isolated_build = true
-envlist = py{38,39,310,311,312}-django{32,42}-psycopg2,py312-django42-psycopg3,report
+envlist =
+    py{38,39,310,311,312}-django32-psycopg2
+    py{38,39,310,311,312}-django42-psycopg2
+    py312-django42-psycopg3
+    py{310,311,312}-django50-psycopg2
+    py312-django50-psycopg3
+    report
 
 [testenv]
 install_command = pip install {opts} --no-compile {packages}
 deps =
     django32: Django>=3.2,<3.3
     django42: Django>=4.2,<4.3
+    django50: Django>=5.0rc1,<5.1
     psycopg2: psycopg2-binary
     psycopg3: psycopg[binary]
 allowlist_externals =
@@ -20,13 +27,13 @@ skip_install = true
 commands =
     bash -c 'poetry export --with dev --without-hashes -f requirements.txt | grep -v "^[dD]jango==" | grep -v "^psycopg2-binary==" | pip install --no-compile -q --no-deps -r /dev/stdin'
     pip install --no-compile -q --no-deps --no-build-isolation -e .
-    pytest --create-db --cov --cov-fail-under=0 --cov-append --cov-config pyproject.toml pgtransaction/
+    pytest --create-db --cov --cov-fail-under=0 --cov-append --cov-config pyproject.toml {posargs}
 
 [testenv:report]
 allowlist_externals =
     coverage
 skip_install = true
-depends = py{38,39,310,311,312}-django{32,42}-psycopg2,py312-django42-psycopg3
+depends = py{38,39,310,311,312}-django{32,42}-psycopg2,py312-django42-psycopg3-py{310,311,312}-django50-psycopg2-py312-django50-psycopg3
 parallel_show_output = true
 commands =
     coverage report --fail-under 100


### PR DESCRIPTION
Support and test against Django 5 with psycopg2 and psycopg3.

Type: feature